### PR TITLE
:sparkles: use username field from alibeez as the source for emails

### DIFF
--- a/src/main/java/com/zenika/proxybeez/alibeez/user/AlibeezUser.java
+++ b/src/main/java/com/zenika/proxybeez/alibeez/user/AlibeezUser.java
@@ -4,16 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Date;
 
-/**
- * Created by marc on 22/05/17.
- */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AlibeezUser {
 
+    private String username;
     private String lastName;
     private String firstName;
     private String operationalManager;
-    private String emailPro;
     private Tags tags;
     private Date arrivalDay;
     private Date leaveDay;
@@ -21,6 +18,10 @@ public class AlibeezUser {
 
     public AlibeezUser() {
     }
+
+    public String getUsername() { return username; }
+
+    public void setUsername(String username) { this.username = username; }
 
     public String getLastName() {
         return lastName;
@@ -44,14 +45,6 @@ public class AlibeezUser {
 
     public void setOperationalManager(String operationalManager) {
         this.operationalManager = operationalManager;
-    }
-
-    public String getEmailPro() {
-        return emailPro;
-    }
-
-    public void setEmailPro(String emailPro) {
-        this.emailPro = emailPro;
     }
 
     public Date getArrivalDay() {
@@ -89,14 +82,15 @@ public class AlibeezUser {
     @Override
     public String toString() {
         return "AlibeezUser{" +
-                "lastName='" + lastName + '\'' +
-                ", firstName='" + firstName + '\'' +
-                ", operationalManager='" + operationalManager + '\'' +
-                ", emailPro='" + emailPro + '\'' +
-                ", arrivalDay=" + arrivalDay +
-                ", leaveDay=" + leaveDay +
-                ", operationalManagerShortUsername=" + operationalManagerShortUsername +
-                '}';
+            "username='" + username + '\'' +
+            ", lastName='" + lastName + '\'' +
+            ", firstName='" + firstName + '\'' +
+            ", operationalManager='" + operationalManager + '\'' +
+            ", tags=" + tags +
+            ", arrivalDay=" + arrivalDay +
+            ", leaveDay=" + leaveDay +
+            ", operationalManagerShortUsername='" + operationalManagerShortUsername + '\'' +
+            '}';
     }
 
     public static class Tags {

--- a/src/main/java/com/zenika/proxybeez/alibeez/user/AlibeezUserProxy.java
+++ b/src/main/java/com/zenika/proxybeez/alibeez/user/AlibeezUserProxy.java
@@ -2,9 +2,6 @@ package com.zenika.proxybeez.alibeez.user;
 
 import java.util.Date;
 
-/**
- * Created by marc on 22/05/2017.
- */
 public class AlibeezUserProxy {
 
     public AlibeezUserProxy(AlibeezUser alibeezUser) {
@@ -37,7 +34,7 @@ public class AlibeezUserProxy {
     }
 
     public String getZenikaEmail() {
-        return this.alibeezUser.getEmailPro();
+        return this.alibeezUser.getUsername();
     }
 
     public Date getArrivalDay() {

--- a/src/main/java/com/zenika/proxybeez/alibeez/user/AlibeezUserRequester.java
+++ b/src/main/java/com/zenika/proxybeez/alibeez/user/AlibeezUserRequester.java
@@ -23,7 +23,7 @@ public class AlibeezUserRequester {
 
     private static String BASE_URL = "/users";
 
-    private static String FIELDS = "fields=lastName,firstName,operationalManager,emailPro,tag.etablissement,arrivalDay,leaveDay,operationalManagerShortUsername";
+    private static String FIELDS = "fields=username,lastName,firstName,operationalManager,tag.etablissement,arrivalDay,leaveDay,operationalManagerShortUsername";
 
     private static String FILTER = "filter=enabled==true&filter=type==EMPLOYEE";
 
@@ -46,13 +46,5 @@ public class AlibeezUserRequester {
         }
 
         return alibeezUsers;
-    }
-
-    private Map<String, AlibeezUser> buildUsersMap(List<AlibeezUser> users) {
-        Map<String, AlibeezUser> map = new HashMap<>();
-        for (AlibeezUser user : users) {
-            map.put(user.getEmailPro(), user);
-        }
-        return map;
     }
 }


### PR DESCRIPTION
HR actually uses the username field to store Zenika emails, and do not always fill the pro email field, which
means downstream cannot rely on the email being present. With the change, email should always be present.