### PR TITLE
🛠 support config file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 # Server port; optional, defaults to '3000'
 PORT=
+
+# Config as JSON; see src/config.js for the schema
+PROXYBEEZ_CONFIG=
+
+# File path to a JSON file containing the config; only used if PROXYBEEZ_CONFIG is empty
+PROXYBEEZ_CONFIG_FILE=config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.env
-*.txt
-users/
 node_modules/
-lastupdate
+.env
+config.json

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,41 @@
+import * as fs from "fs";
 import { typecheckConfig } from "./config.js";
 import { createServer } from "./server.js";
 
 const PORT = process.env.PORT || 3000;
-const CONFIG = parseConfig(process.env.PROXYBEEZ_CONFIG);
+const CONFIG = readConfig(
+  process.env.PROXYBEEZ_CONFIG,
+  process.env.PROXYBEEZ_CONFIG_FILE
+);
 
 createServer(CONFIG).listen(PORT, () => {
   console.log(`Listening on port ${PORT}`);
 });
+
+/**
+ *
+ * @param {string | undefined} envConfig
+ * @param {string | undefined} fileConfig
+ */
+function readConfig(envConfig, fileConfig) {
+  if (envConfig) {
+    return parseConfig(envConfig);
+  }
+  if (!fileConfig) {
+    throw new Error(
+      `environment variable PROXYBEEZ_CONFIG and PROXYBEEZ_CONFIG_FILE are both empty; please set either one`
+    );
+  }
+  let fileContent;
+  try {
+    fileContent = fs.readFileSync(fileConfig).toString();
+  } catch (err) {
+    throw new Error(
+      `environment variable PROXYBEEZ_CONFIG is empty and PROXYBEEZ_CONFIG_FILE is '${fileConfig}' which does not point to a file that could be read: ${err.message}`
+    );
+  }
+  return parseConfig(fileContent);
+}
 
 /**
  *


### PR DESCRIPTION
A config file is more convenient in dev than a big json string in .env