### PR TITLE
🐛 fix server error when missing param

### DIFF
--- a/src/renderPathTemplate.js
+++ b/src/renderPathTemplate.js
@@ -9,8 +9,9 @@ import * as querystring from "querystring";
 export default function renderPathTemplate(template, searchParams) {
   return template.replace(/\${(.*?)}/g, (_, $1) => {
     if (!searchParams.has($1)) {
-      throw new TypeError(
-        `Cannot render template: missing value for key '${$1}'`
+      throw Object.assign(
+        new Error(`Cannot render template: missing value for key '${$1}'`),
+        { key: $1 }
       );
     }
     return querystring.escape(searchParams.get($1) ?? "");

--- a/src/renderPathTemplate.test.js
+++ b/src/renderPathTemplate.test.js
@@ -46,7 +46,7 @@ import renderPathTemplate from "./renderPathTemplate.js";
 {
   assert.throws(
     () => renderPathTemplate("${var}", new URLSearchParams()),
-    TypeError,
+    { key: "var" },
     "'renderPathTemplate' does not throw on missing key"
   );
 }


### PR DESCRIPTION
Server was responding 500 instead of 400.