### PR TITLE
✨ path-level tenant allowlist

### DIFF
--- a/src/alibeez.js
+++ b/src/alibeez.js
@@ -28,9 +28,13 @@ export async function requestAlibeez(url, alibeezConfig, pathConfig) {
  */
 function requestAlibeezTenants(url, tenants, pathConfig) {
   return asyncMap(
-    Object.values(tenants).map((tenant) =>
-      mergeProcessors(tenant.processors, pathConfig.processors)
-    ),
+    Object.entries(tenants)
+      .filter(
+        ([name]) => !pathConfig.tenants || pathConfig.tenants.includes(name)
+      )
+      .map(([, tenant]) =>
+        mergeProcessors(tenant.processors, pathConfig.processors)
+      ),
     requestAlibeezTenant(url)
   );
 }

--- a/src/config.js
+++ b/src/config.js
@@ -269,7 +269,7 @@ function typecheckPathConfig(config) {
   }
   if (typeof config.path !== "string") {
     throw new TypeError(
-      "Invalid configuration: one of $.paths[*].path is not an string"
+      "Invalid configuration: one of $.paths[*].path is not a string"
     );
   }
   /** @type PathConfig */ const result = { key: config.key, path: config.path };
@@ -278,6 +278,21 @@ function typecheckPathConfig(config) {
       config.processors,
       "one of $.paths[*].processors"
     );
+  }
+  if (hasProperty(config, "tenants")) {
+    if (!isArray(config.tenants)) {
+      throw new TypeError(
+        `Invalid configuration: one of $.paths[*].tenants is not an array`
+      );
+    }
+    result.tenants = config.tenants.map((field) => {
+      if (typeof field !== "string") {
+        throw new TypeError(
+          `Invalid configuration: one of $.paths[*].tenants[*] is not a string`
+        );
+      }
+      return field;
+    });
   }
   if (hasProperty(config, "mock")) {
     result.mock = config.mock;

--- a/src/config.types.ts
+++ b/src/config.types.ts
@@ -52,4 +52,5 @@ type PathConfig = {
   path: string;
   mock?: unknown;
   processors?: ProcessorsConfig;
+  tenants?: string[];
 };


### PR DESCRIPTION
Allows paths to select which tenants to request. Useful when the request includes a filter that would yield no results (or an error) on other tenants.